### PR TITLE
sbt 1.3 / Coursier support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,14 +41,16 @@ libraryDependencies ++= javaFXModules.map {m=>
 //
 // This clearly isn't a solution for running a finished product. It might be worth looking at the "sbt-native-packager"
 // plugin to verify whether that addresses the issue of installing and running a product on a user's machine.
-val fs = File.separator
-val ivyHome = Option(sys.props("sbt.ivy.home")).getOrElse(s"${sys.props("user.home")}${fs}.ivy2")
-val fxRoot = s"$ivyHome${fs}cache${fs}org.openjfx${fs}javafx-"
-val fxPaths = javaFXModules.map {m =>
-  s"$fxRoot$m${fs}jars${fs}javafx-$m-11-$osName.jar"
+val javaFxModulesPaths = taskKey[String]("Get the joined paths to OpenJFX jars.")
+
+javaFxModulesPaths := {
+  val files = update.value.select(module = moduleFilter(
+      organization = "org.openjfx",
+    ))
+  files.map(_.absolutePath).mkString(File.pathSeparator)
 }
+
 javaOptions ++= Seq(
-  "--module-path", fxPaths.mkString(File.pathSeparator),
+  "--module-path", javaFxModulesPaths.value,
   "--add-modules", "ALL-MODULE-PATH"
 )
-

--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,13 @@
 import java.io.File
 
 // Name of the project
-name := "JavaFX 11 Hello World"
+name := "JavaFX 14 Hello World"
 
 // Project version
 version := "1.0.0-SNAPSHOT"
 
 // Version of Scala used by the project
-scalaVersion := "2.13.0"
+scalaVersion := "2.13.1"
 
 // Add dependency on JavaFX library
 
@@ -33,7 +33,7 @@ lazy val osName = System.getProperty("os.name") match {
 // Add JavaFX dependencies
 lazy val javaFXModules = Seq("base", "controls", "fxml", "graphics", "media", "swing", "web")
 libraryDependencies ++= javaFXModules.map {m=>
-  "org.openjfx" % s"javafx-$m" % "11" classifier osName
+  "org.openjfx" % s"javafx-$m" % "14" classifier osName
 }
 
 // When forking, we need to tell the running process how to find the necessary modules (SBT currently doesn't appear to

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.8


### PR DESCRIPTION
With sbt 1.3 the default location has changed from `.ivy2` to `.cache/coursier`.

Instead of manual string building, `update.value.select` can be used to get the actual file location, regardless whether coursier or ivy is used / sbt 1.2 or sbt 1.3 is used.

The update from OpenJFX 11 to 14 makes no difference, just to keep this demonstration up to date.